### PR TITLE
Extend parse tree with range and position indices in input query string

### DIFF
--- a/cql.js
+++ b/cql.js
@@ -346,6 +346,7 @@ CQLParser.prototype = {
     },
     _parseModifiers: function () {
         var ar = new Array();
+        let _safeExprStart = this._exprStart;
         while (this.look == "/") {
             let _mstart = this.qi;
             this._move();
@@ -384,6 +385,7 @@ CQLParser.prototype = {
                 ar.push(m);
             }
         }
+        this._exprStart = _safeExprStart;
         return ar;
     },
     _parseSearchClause: function (field, relation, modifiers) {

--- a/cql.js
+++ b/cql.js
@@ -419,6 +419,7 @@ CQLParser.prototype = {
                     this.lval != "not" &&
                     this.lval != "prox")) {
                 var rel = this.val;    // string relation
+                this._exprRelStart = this.qi - this.val.length + 1;
                 this._move();
                 return this._parseSearchClause(first, rel,
                     this._parseModifiers());

--- a/cql.js
+++ b/cql.js
@@ -165,8 +165,8 @@ CQLSearchClause.prototype = {
             default: return rel;
         }
     }
-
 }
+
 // CQLBoolean
 var CQLBoolean = function () {
     this.op = null;
@@ -184,6 +184,7 @@ CQLBoolean.prototype = {
             (this.modifiers.length > 0 ? '/' + this.modifiers.join('/') : '') +
             ' ' + (this.right.op ? '(' + this.right + ')' : this.right);;
     },
+
     toXCQL: function (n, c) {
         var s = indent(n, c) + "<triple>\n";
         s = s + indent(n + 1, c) + "<boolean>\n" +
@@ -219,6 +220,7 @@ CQLBoolean.prototype = {
     }
 
 }
+
 // CQLParser
 var CQLParser = function () {
     this.qi = null;

--- a/cql.js
+++ b/cql.js
@@ -13,10 +13,15 @@ function indent(n, c) {
 var CQLError = function (message, query, pos, look, val, lval) {
     this.name = "CQLError";
     this.message = message;
+    // raw query string
     this.query = query;
+    // parser (error) position in raw query
     this.pos = pos;
+    // state: s | q | | ()/ | <>= | "'
     this.look = look;
+    // value of token (may be (quoted) content, "index"; field or term)
     this.val = val;
+    // lowercased this.val
     this.lval = lval;
     this.stack = (new Error()).stack;
 }
@@ -24,8 +29,11 @@ CQLError.prototype = Object.create(Error.prototype);
 
 // CQLModifier
 var CQLModifier = function () {
+    // name of (relation) modifier
     this.name = null;
+    // relation of modifier value (e.g. equals, lower than, etc.)
     this.relation = null;
+    // optional value of modifier ("true" if empty)
     this.value = null;
     this._pos = null;
     this._range = null;
@@ -63,16 +71,25 @@ CQLModifier.prototype = {
 // CQLSearchClause
 var CQLSearchClause = function (field, fielduri, relation, relationuri,
     modifiers, term, scf, scr) {
+    // index or name
     this.field = field;
+    // not supported yet? (always empty string)
     this.fielduri = fielduri;
+    // relation symbol or string
     this.relation = relation;
+    // not supported yet? (always empty string)
     this.relationuri = relationuri;
+    // list of modifiers
     this.modifiers = modifiers;
+    // value
     this.term = term;
     this.scf = scf || DEFAULT_SERVER_CHOICE_FIELD;
     this.scr = scr || DEFAULT_SERVER_CHOICE_RELATION;
+    // start position of search clause
     this._pos = null;
+    // range (start + end position) of search clause (without surrounding braces or spaces)
     this._range = null;
+    // start position of relation
     this._relpos = null;
 }
 
@@ -169,9 +186,13 @@ CQLSearchClause.prototype = {
 
 // CQLBoolean
 var CQLBoolean = function () {
+    // operator: and | or | not | prox
     this.op = null;
+    // list of modifiers
     this.modifiers = null;
+    // left search clause
     this.left = null;
+    // right search clause
     this.right = null;
     this._pos = null;
     this._range = null;
@@ -223,15 +244,25 @@ CQLBoolean.prototype = {
 
 // CQLParser
 var CQLParser = function () {
+    // index/position in raw query
     this.qi = null;
+    // raw query string length (char count)
     this.ql = null;
+    // raw query string
     this.qs = null;
+    // parser state: s | q | ()/ | <>= | "'
+    // if empty string then error
     this.look = null;
+    // lowercased this.val
     this.lval = null;
+    // value of token (may be (quoted) content, "index"; field or term)
     this.val = null;
+    // (internal) start position of expression
     this._exprStart = null;
+    // (internal) start position of relation (in expression)
     this._exprRelStart = null;
     this.prefixes = new Object();
+    // parsed query
     this.tree = null;
     this.scf = null;
     this.scr = null;

--- a/cql.js
+++ b/cql.js
@@ -513,3 +513,6 @@ CQLParser.prototype = {
         this.prefixes[name] = value;
     }
 }
+
+// for module import systems uncomment the following line
+// module.exports = CQLParser;

--- a/cql.js
+++ b/cql.js
@@ -352,6 +352,7 @@ CQLParser.prototype = {
     _parseModifiers: function () {
         var ar = new Array();
         let _safeExprStart = this._exprStart;
+        let _safeExprRelStart = this._exprRelStart;
         while (this.look == "/") {
             let _mstart = this.qi;
             this._move();
@@ -391,6 +392,7 @@ CQLParser.prototype = {
             }
         }
         this._exprStart = _safeExprStart;
+        this._exprRelStart = _safeExprRelStart;
         return ar;
     },
     _parseSearchClause: function (field, relation, modifiers) {

--- a/cql.js
+++ b/cql.js
@@ -73,6 +73,7 @@ var CQLSearchClause = function (field, fielduri, relation, relationuri,
     this.scr = scr || DEFAULT_SERVER_CHOICE_RELATION;
     this._pos = null;
     this._range = null;
+    this._relpos = null;
 }
 
 CQLSearchClause.prototype = {
@@ -136,6 +137,7 @@ CQLSearchClause.prototype = {
         }
         if (this._pos !== null) s += ', "@pos": ' + this._pos;
         if (this._range !== null) s += ', "@range": ' + JSON.stringify(this._range);
+        if (this._relpos !== null) s += ', "relation@pos": ' + this._relpos;
         s += '}';
         return s;
     },
@@ -226,6 +228,7 @@ var CQLParser = function () {
     this.lval = null;
     this.val = null;
     this._exprStart = null;
+    this._exprRelStart = null;
     this.prefixes = new Object();
     this.tree = null;
     this.scf = null;
@@ -451,7 +454,8 @@ CQLParser.prototype = {
                     this.scf,
                     this.scr);
                 sc._range = [this._exprStart, _tend];
-                this._exprStart = null;
+                sc._relpos = this._exprRelStart;
+                this._exprStart = this._exprRelStart = null;
                 return sc;
             }
             // prefixes
@@ -499,6 +503,7 @@ CQLParser.prototype = {
         } else if (this._strchr("<>=", c)) {
             this.look = c;
             this.qi++;
+            this._exprRelStart = this.qi;
             //comparitors can repeat, could be if
             while (this.qi < this.ql
                 && this._strchr("<>=", this.qs.charAt(this.qi))) {

--- a/cql.js
+++ b/cql.js
@@ -18,19 +18,19 @@ var CQLModifier = function () {
 
 CQLModifier.prototype = {
     toString: function () {
-      return this.name + this.relation + this.value;
+        return this.name + this.relation + this.value;
     },
 
     toXCQL: function (n, c) {
-        var s = indent(n+1, c) + "<modifier>\n";
-        s = s + indent(n+2, c) + "<name>" + this.name + "</name>\n";
+        var s = indent(n + 1, c) + "<modifier>\n";
+        s = s + indent(n + 2, c) + "<name>" + this.name + "</name>\n";
         if (this.relation != null)
-            s = s + indent(n+2, c) 
+            s = s + indent(n + 2, c)
                 + "<relation>" + this.relation + "</relation>\n";
         if (this.value != null)
-            s = s + indent(n+2, c) 
-                + "<value>" + this.value +"</value>\n";
-        s = s + indent(n+1, c) + "</modifier>\n";
+            s = s + indent(n + 2, c)
+                + "<value>" + this.value + "</value>\n";
+        s = s + indent(n + 1, c) + "</modifier>\n";
         return s;
     },
 
@@ -38,14 +38,14 @@ CQLModifier.prototype = {
         //we ignore modifier relation symbol, for value-less modifiers
         //we assume 'true'
         var value = this.value.length > 0 ? this.value : "true";
-        var s = '"'+this.name+'": "'+value+'"';
+        var s = '"' + this.name + '": "' + value + '"';
         return s;
     }
 }
 
 // CQLSearchClause
-var CQLSearchClause = function (field, fielduri, relation, relationuri, 
-                                modifiers, term, scf, scr) {
+var CQLSearchClause = function (field, fielduri, relation, relationuri,
+    modifiers, term, scf, scr) {
     this.field = field;
     this.fielduri = fielduri;
     this.relation = relation;
@@ -58,95 +58,94 @@ var CQLSearchClause = function (field, fielduri, relation, relationuri,
 
 CQLSearchClause.prototype = {
     toString: function () {
-      var field = this.field;
-      var relation = this.relation;
-      if (field == this.scf && relation == this.scr) {
-        //avoid redundant field/relation
-        field = null;
-        relation = null;
-      }
-      return (field ? field + ' ' : '') + 
-        (relation ? relation : '') +
-        (this.modifiers.length > 0 ? '/' + this.modifiers.join('/') : '') +
-        (relation || this.modifiers.length ? ' ' : '') +
-        '"' + this.term + '"';
+        var field = this.field;
+        var relation = this.relation;
+        if (field == this.scf && relation == this.scr) {
+            //avoid redundant field/relation
+            field = null;
+            relation = null;
+        }
+        return (field ? field + ' ' : '') +
+            (relation ? relation : '') +
+            (this.modifiers.length > 0 ? '/' + this.modifiers.join('/') : '') +
+            (relation || this.modifiers.length ? ' ' : '') +
+            '"' + this.term + '"';
     },
 
     toXCQL: function (n, c) {
         var s = indent(n, c) + "<searchClause>\n";
-        if (this.fielduri.length > 0)
-        {
-            s = s + indent(n+1, c) + "<prefixes>\n" +
-                indent(n+2, c) + "<prefix>\n" +
-                indent(n+3, c) + "<identifier>" + this.fielduri +
+        if (this.fielduri.length > 0) {
+            s = s + indent(n + 1, c) + "<prefixes>\n" +
+                indent(n + 2, c) + "<prefix>\n" +
+                indent(n + 3, c) + "<identifier>" + this.fielduri +
                 "</identifier>\n" +
-                indent(n+2, c) + "</prefix>\n" +
-                indent(n+1, c) + "</prefixes>\n";
+                indent(n + 2, c) + "</prefix>\n" +
+                indent(n + 1, c) + "</prefixes>\n";
         }
-        s = s + indent(n+1, c) + "<index>" + this.field + "</index>\n";
-        s = s + indent(n+1, c) + "<relation>\n";
+        s = s + indent(n + 1, c) + "<index>" + this.field + "</index>\n";
+        s = s + indent(n + 1, c) + "<relation>\n";
         if (this.relationuri.length > 0) {
-            s = s + indent(n+2, c) +
+            s = s + indent(n + 2, c) +
                 "<identifier>" + this.relationuri + "</identifier>\n";
         }
-        s = s + indent(n+2, c) + "<value>" + this.relation + "</value>\n";
+        s = s + indent(n + 2, c) + "<value>" + this.relation + "</value>\n";
         if (this.modifiers.length > 0) {
-            s = s + indent(n+2, c) + "<modifiers>\n";
+            s = s + indent(n + 2, c) + "<modifiers>\n";
             for (var i = 0; i < this.modifiers.length; i++)
-                s = s + this.modifiers[i].toXCQL(n+2, c);
-            s = s + indent(n+2, c) + "</modifiers>\n";
+                s = s + this.modifiers[i].toXCQL(n + 2, c);
+            s = s + indent(n + 2, c) + "</modifiers>\n";
         }
-        s = s + indent(n+1, c) + "</relation>\n";
-        s = s + indent(n+1, c) + "<term>" + this.term + "</term>\n";
+        s = s + indent(n + 1, c) + "</relation>\n";
+        s = s + indent(n + 1, c) + "<term>" + this.term + "</term>\n";
         s = s + indent(n, c) + "</searchClause>\n";
         return s;
     },
 
     toFQ: function () {
-        var s = '{"term": "'+this.term+'"';
+        var s = '{"term": "' + this.term + '"';
         if (this.field.length > 0 && this.field != this.scf)
-          s+= ', "field": "'+this.field+'"';
+            s += ', "field": "' + this.field + '"';
         if (this.relation.length > 0 && this.relation != this.scr)
-          s+= ', "relation": "'+this._mapRelation(this.relation)+'"';
+            s += ', "relation": "' + this._mapRelation(this.relation) + '"';
         for (var i = 0; i < this.modifiers.length; i++) {
-          //since modifiers are mapped to keys, ignore the reserved ones
-          if (this.modifiers[i].name == "term"
-            ||this.modifiers[i].name == "field"
-            ||this.modifiers[i].name == "relation")
-            continue;
-          s += ', ' + this.modifiers[i].toFQ();
+            //since modifiers are mapped to keys, ignore the reserved ones
+            if (this.modifiers[i].name == "term"
+                || this.modifiers[i].name == "field"
+                || this.modifiers[i].name == "relation")
+                continue;
+            s += ', ' + this.modifiers[i].toFQ();
         }
         s += '}';
         return s;
     },
 
     _mapRelation: function (rel) {
-      switch(rel) {
-        case "<" : return "lt";
-        case ">" : return "gt";
-        case "=" : return "eq";
-        case "<>" : return "ne";
-        case ">=" : return "ge";
-        case "<=" : return "le";
-        default: return rel;
-      }
+        switch (rel) {
+            case "<": return "lt";
+            case ">": return "gt";
+            case "=": return "eq";
+            case "<>": return "ne";
+            case ">=": return "ge";
+            case "<=": return "le";
+            default: return rel;
+        }
     },
 
     _remapRelation: function (rel) {
-      switch(rel) {
-        case "lt" : return "<";
-        case "gt" : return ">";
-        case "eq" : return "=";
-        case "ne" : return "<>";
-        case "ge" : return ">=";
-        case "le" : return "<=";
-        default: return rel;
-      }
+        switch (rel) {
+            case "lt": return "<";
+            case "gt": return ">";
+            case "eq": return "=";
+            case "ne": return "<>";
+            case "ge": return ">=";
+            case "le": return "<=";
+            default: return rel;
+        }
     }
 
 }
 // CQLBoolean
-var CQLBoolean = function() {
+var CQLBoolean = function () {
     this.op = null;
     this.modifiers = null;
     this.left = null;
@@ -155,41 +154,41 @@ var CQLBoolean = function() {
 
 CQLBoolean.prototype = {
     toString: function () {
-      return (this.left.op ? '(' + this.left + ')' : this.left) + ' ' + 
-        this.op.toUpperCase() +
-        (this.modifiers.length > 0 ? '/' + this.modifiers.join('/') : '') + 
-        ' ' + (this.right.op ? '(' + this.right + ')' : this.right);;
+        return (this.left.op ? '(' + this.left + ')' : this.left) + ' ' +
+            this.op.toUpperCase() +
+            (this.modifiers.length > 0 ? '/' + this.modifiers.join('/') : '') +
+            ' ' + (this.right.op ? '(' + this.right + ')' : this.right);;
     },
     toXCQL: function (n, c) {
         var s = indent(n, c) + "<triple>\n";
-        s = s + indent(n+1, c) + "<boolean>\n" +
-            indent(n+2, c) + "<value>" + this.op + "</value>\n";
+        s = s + indent(n + 1, c) + "<boolean>\n" +
+            indent(n + 2, c) + "<value>" + this.op + "</value>\n";
         if (this.modifiers.length > 0) {
-            s = s + indent(n+2, c) + "<modifiers>\n";
+            s = s + indent(n + 2, c) + "<modifiers>\n";
             for (var i = 0; i < this.modifiers.length; i++)
-                s = s + this.modifiers[i].toXCQL(n+2, c);
-            s = s + indent(n+2, c) + "</modifiers>\n";
+                s = s + this.modifiers[i].toXCQL(n + 2, c);
+            s = s + indent(n + 2, c) + "</modifiers>\n";
         }
-        s = s + indent(n+1, c) + "</boolean>\n";
-        s = s + indent(n+1, c) + "<leftOperand>\n" +
-            this.left.toXCQL(n+2, c) + indent(n+1, c) + "</leftOperand>\n";
+        s = s + indent(n + 1, c) + "</boolean>\n";
+        s = s + indent(n + 1, c) + "<leftOperand>\n" +
+            this.left.toXCQL(n + 2, c) + indent(n + 1, c) + "</leftOperand>\n";
 
-        s = s + indent(n+1, c) + "<rightOperand>\n" +
-            this.right.toXCQL(n+2, c) + indent(n+1, c) + "</rightOperand>\n";
+        s = s + indent(n + 1, c) + "<rightOperand>\n" +
+            this.right.toXCQL(n + 2, c) + indent(n + 1, c) + "</rightOperand>\n";
         s = s + indent(n, c) + "</triple>\n";
         return s;
     },
 
     toFQ: function (n, c, nl) {
-      var s = '{"op": "'+this.op+'"';
-      //proximity modifiers
-      for (var i = 0; i < this.modifiers.length; i++)
-        s += ', ' + this.modifiers[i].toFQ();
-      s += ','+nl+indent(n, c)+' "s1": '+this.left.toFQ(n+1, c, nl);
-      s += ','+nl+indent(n, c)+' "s2": '+this.right.toFQ(n+1, c, nl);
-      var fill = n && c ? ' ' : '';
-      s += nl+indent(n-1, c)+fill+'}';
-      return s;
+        var s = '{"op": "' + this.op + '"';
+        //proximity modifiers
+        for (var i = 0; i < this.modifiers.length; i++)
+            s += ', ' + this.modifiers[i].toFQ();
+        s += ',' + nl + indent(n, c) + ' "s1": ' + this.left.toFQ(n + 1, c, nl);
+        s += ',' + nl + indent(n, c) + ' "s2": ' + this.right.toFQ(n + 1, c, nl);
+        var fill = n && c ? ' ' : '';
+        s += nl + indent(n - 1, c) + fill + '}';
+        return s;
     }
 
 }
@@ -211,77 +210,77 @@ CQLParser.prototype = {
     parse: function (query, scf, scr) {
         if (!query)
             throw new Error("The query to be parsed cannot be empty");
-        this.scf = typeof scf != 'string' 
-          ? DEFAULT_SERVER_CHOICE_FIELD : scf;
-        this.scr = typeof scr != 'string' 
-          ? DEFAULT_SERVER_CHOICE_RELATION : scr; 
+        this.scf = typeof scf != 'string'
+            ? DEFAULT_SERVER_CHOICE_FIELD : scf;
+        this.scr = typeof scr != 'string'
+            ? DEFAULT_SERVER_CHOICE_RELATION : scr;
         this.qs = query;
         this.ql = this.qs.length;
         this.qi = 0;
-        this._move(); 
+        this._move();
         this.tree = this._parseQuery(this.scf, this.scr, new Array());
         if (this.look != "")
             throw new Error("EOF expected");
     },
     parseFromFQ: function (query, scf, scr) {
-       if (!query)
-          throw new Error("The query to be parsed cannot be empty");
-       if (typeof query == 'string')
-         query = JSON.parse(query);
-       this.scf = typeof scf != 'string' 
-         ? DEFAULT_SERVER_CHOICE_FIELD : scf;
-       this.scr = typeof scr != 'string' 
-         ? DEFAULT_SERVER_CHOICE_RELATION : scr;
-       this.tree = this._parseFromFQ(query);
+        if (!query)
+            throw new Error("The query to be parsed cannot be empty");
+        if (typeof query == 'string')
+            query = JSON.parse(query);
+        this.scf = typeof scf != 'string'
+            ? DEFAULT_SERVER_CHOICE_FIELD : scf;
+        this.scr = typeof scr != 'string'
+            ? DEFAULT_SERVER_CHOICE_RELATION : scr;
+        this.tree = this._parseFromFQ(query);
     },
     _parseFromFQ: function (fq) {
         //op-node
-        if (fq.hasOwnProperty('op') 
+        if (fq.hasOwnProperty('op')
             && fq.hasOwnProperty('s1')
             && fq.hasOwnProperty('s2')) {
-          var node = new CQLBoolean();
-          node.op = fq.op;
-          node.left = this._parseFromFQ(fq.s1);
-          node.right = this._parseFromFQ(fq.s2);
-          //include all other members as modifiers
-          node.modifiers = [];
-          for (var key in fq) {
-            if (key == 'op' || key == 's1' || key == 's2')
-              continue;
-            var mod = new CQLModifier();
-            mod.name = key;
-            mod.relation = '=';
-            mod.value = fq[key];
-            node.modifiers.push(mod);
-          }
-          return node;
+            var node = new CQLBoolean();
+            node.op = fq.op;
+            node.left = this._parseFromFQ(fq.s1);
+            node.right = this._parseFromFQ(fq.s2);
+            //include all other members as modifiers
+            node.modifiers = [];
+            for (var key in fq) {
+                if (key == 'op' || key == 's1' || key == 's2')
+                    continue;
+                var mod = new CQLModifier();
+                mod.name = key;
+                mod.relation = '=';
+                mod.value = fq[key];
+                node.modifiers.push(mod);
+            }
+            return node;
         }
         //search-clause node
         if (fq.hasOwnProperty('term')) {
-          var node = new CQLSearchClause();
-          node.term = fq.term;
-          node.scf = this.scf;
-          node.scr = this.scr;
-          node.field = fq.hasOwnProperty('field') 
-            ? fq.field : this.scf;
-          node.relation = fq.hasOwnProperty('relation')
-            ? node._remapRelation(fq.relation) : this.scr;
-          //include all other members as modifiers
-          node.relationuri = '';
-          node.fielduri = '';
-          node.modifiers = [];
-          for (var key in fq) {
-            if (key == 'term' || key == 'field' || key == 'relation')
-              continue;
-            var mod = new CQLModifier();
-            mod.name = key;
-            mod.relation = '=';
-            mod.value = fq[key];
-            node.modifiers.push(mod);
-          }
-          return node;
+            var node = new CQLSearchClause();
+            node.term = fq.term;
+            node.scf = this.scf;
+            node.scr = this.scr;
+            node.field = fq.hasOwnProperty('field')
+                ? fq.field : this.scf;
+            node.relation = fq.hasOwnProperty('relation')
+                ? node._remapRelation(fq.relation) : this.scr;
+            //include all other members as modifiers
+            node.relationuri = '';
+            node.fielduri = '';
+            node.modifiers = [];
+            for (var key in fq) {
+                if (key == 'term' || key == 'field' || key == 'relation')
+                    continue;
+                var mod = new CQLModifier();
+                mod.name = key;
+                mod.relation = '=';
+                mod.value = fq[key];
+                node.modifiers.push(mod);
+            }
+            return node;
         }
-        throw new Error('Unknow node type; '+JSON.stringify(fq));
+        throw new Error('Unknow node type; ' + JSON.stringify(fq));
     },
     toXCQL: function (c) {
         c = typeof c == "undefined" ? ' ' : c;
@@ -295,13 +294,13 @@ CQLParser.prototype = {
     toString: function () {
         return this.tree.toString();
     },
-    _parseQuery: function(field, relation, modifiers) {
+    _parseQuery: function (field, relation, modifiers) {
         var left = this._parseSearchClause(field, relation, modifiers);
         while (this.look == "s" && (
-                    this.lval == "and" ||
-                    this.lval == "or" ||
-                    this.lval == "not" ||
-                    this.lval == "prox")) {
+            this.lval == "and" ||
+            this.lval == "or" ||
+            this.lval == "not" ||
+            this.lval == "prox")) {
             var b = new CQLBoolean();
             b.op = this.lval;
             this._move();
@@ -312,22 +311,22 @@ CQLParser.prototype = {
         }
         return left;
     },
-    _parseModifiers: function() {
+    _parseModifiers: function () {
         var ar = new Array();
         while (this.look == "/") {
             this._move();
             if (this.look != "s" && this.look != "q")
                 throw new Error("Invalid modifier.")
-            
+
             var name = this.lval;
             this._move();
-            if (this.look.length > 0 
+            if (this.look.length > 0
                 && this._strchr("<>=", this.look.charAt(0))) {
                 var rel = this.look;
                 this._move();
                 if (this.look != "s" && this.look != "q")
                     throw new Error("Invalid relation within the modifier.");
-                
+
                 var m = new CQLModifier();
                 m.name = name;
                 m.relation = rel;
@@ -344,7 +343,7 @@ CQLParser.prototype = {
         }
         return ar;
     },
-    _parseSearchClause: function(field, relation, modifiers) {
+    _parseSearchClause: function (field, relation, modifiers) {
         if (this.look == "(") {
             this._move();
             var b = this._parseQuery(field, relation, modifiers);
@@ -358,32 +357,32 @@ CQLParser.prototype = {
             var first = this.val;   // dont know if field or term yet
             this._move();
             if (this.look == "q" ||
-                    (this.look == "s" &&
-                     this.lval != "and" &&
-                     this.lval != "or" &&
-                     this.lval != "not" &&
-                     this.lval != "prox")) {
+                (this.look == "s" &&
+                    this.lval != "and" &&
+                    this.lval != "or" &&
+                    this.lval != "not" &&
+                    this.lval != "prox")) {
                 var rel = this.val;    // string relation
                 this._move();
                 return this._parseSearchClause(first, rel,
-                                               this._parseModifiers());
-            } else if (this.look.length > 0 
-                       && this._strchr("<>=", this.look.charAt(0))) {
+                    this._parseModifiers());
+            } else if (this.look.length > 0
+                && this._strchr("<>=", this.look.charAt(0))) {
                 var rel = this.look;   // other relation <, = ,etc
                 this._move();
-                return this._parseSearchClause(first, rel, 
-                                               this._parseModifiers());
+                return this._parseSearchClause(first, rel,
+                    this._parseModifiers());
             } else {
                 // it's a search term
                 var pos = field.indexOf('.');
                 var pre = "";
                 if (pos != -1)
                     pre = field.substring(0, pos);
-                
+
                 var uri = this._lookupPrefix(pre);
                 if (uri.length > 0)
-                    field = field.substring(pos+1);
-                
+                    field = field.substring(pos + 1);
+
                 pos = relation.indexOf('.');
                 if (pos == -1)
                     pre = "cql";
@@ -392,32 +391,31 @@ CQLParser.prototype = {
 
                 var reluri = this._lookupPrefix(pre);
                 if (reluri.Length > 0)
-                    relation = relation.Substring(pos+1);
+                    relation = relation.Substring(pos + 1);
 
                 var sc = new CQLSearchClause(field,
-                        uri,
-                        relation,
-                        reluri,
-                        modifiers,
-                        first,
-                        this.scf,
-                        this.scr);
+                    uri,
+                    relation,
+                    reluri,
+                    modifiers,
+                    first,
+                    this.scf,
+                    this.scr);
                 return sc;
             }
-        // prefixes
+            // prefixes
         } else if (this.look == ">") {
             this._move();
             if (this.look != "s" && this.look != "q")
                 throw new Error("Expecting string or a quoted expression.");
-            
+
             var first = this.lval;
             this._move();
-            if (this.look == "=")
-            {
+            if (this.look == "=") {
                 this._move();
                 if (this.look != "s" && this.look != "q")
                     throw new Error("Expecting string or a quoted expression.");
-                
+
                 this._addPrefix(first, this.lval);
                 this._move();
                 return this._parseQuery(field, relation, modifiers);
@@ -432,8 +430,8 @@ CQLParser.prototype = {
     },
     _move: function () {
         //eat whitespace
-        while (this.qi < this.ql 
-               && this._strchr(" \t\r\n", this.qs.charAt(this.qi)))
+        while (this.qi < this.ql
+            && this._strchr(" \t\r\n", this.qs.charAt(this.qi)))
             this.qi++;
         //eof
         if (this.qi == this.ql) {
@@ -446,17 +444,17 @@ CQLParser.prototype = {
         if (this._strchr("()/", c)) {
             this.look = c;
             this.qi++;
-        //comparitor
+            //comparitor
         } else if (this._strchr("<>=", c)) {
             this.look = c;
             this.qi++;
             //comparitors can repeat, could be if
-            while (this.qi < this.ql 
-                   && this._strchr("<>=", this.qs.charAt(this.qi))) {
+            while (this.qi < this.ql
+                && this._strchr("<>=", this.qs.charAt(this.qi))) {
                 this.look = this.look + this.qs.charAt(this.qi);
                 this.qi++;
             }
-        //quoted string
+            //quoted string
         } else if (this._strchr("\"'", c)) {
             this.look = "q";
             //remember quote char
@@ -465,26 +463,26 @@ CQLParser.prototype = {
             this.val = "";
             var escaped = false;
             while (this.qi < this.ql) {
-              if (!escaped && this.qs.charAt(this.qi) == mark)
-                break;
-              if (!escaped && this.qs.charAt(this.qi) == '\\')
-                escaped = true;
-              else
-                escaped = false;
-              this.val += this.qs.charAt(this.qi);
-              this.qi++;
+                if (!escaped && this.qs.charAt(this.qi) == mark)
+                    break;
+                if (!escaped && this.qs.charAt(this.qi) == '\\')
+                    escaped = true;
+                else
+                    escaped = false;
+                this.val += this.qs.charAt(this.qi);
+                this.qi++;
             }
             this.lval = this.val.toLowerCase();
             if (this.qi < this.ql)
                 this.qi++;
             else //unterminated
-              this.look = ""; //notify error
-        //unquoted string
+                this.look = ""; //notify error
+            //unquoted string
         } else {
             this.look = "s";
             this.val = "";
-            while (this.qi < this.ql 
-                   && !this._strchr("()/<>= \t\r\n", this.qs.charAt(this.qi))) {
+            while (this.qi < this.ql
+                && !this._strchr("()/<>= \t\r\n", this.qs.charAt(this.qi))) {
                 this.val = this.val + this.qs.charAt(this.qi);
                 this.qi++;
             }
@@ -494,10 +492,10 @@ CQLParser.prototype = {
     _strchr: function (s, ch) {
         return s.indexOf(ch) >= 0
     },
-    _lookupPrefix: function(name) {
+    _lookupPrefix: function (name) {
         return this.prefixes[name] ? this.prefixes[name] : "";
     },
-    _addPrefix: function(name, value) {
+    _addPrefix: function (name, value) {
         //overwrite existing items
         this.prefixes[name] = value;
     }

--- a/index.html
+++ b/index.html
@@ -9,23 +9,29 @@
           cp.parse(query);
           var fq = JSON.parse(cp.toFQ());
 
-          function recMods (obj, s) {
+          function recMods (obj, s, lvl) {
+            if (lvl === undefined) lvl = 0;
             if ("term" in obj) {
+              if ("@range" in obj) {
+                let range = obj["@range"];
+                s += '\n' + ("".padStart(range[0] - 1) + "t".padEnd(range[1] - range[0] + 1, "-")).padEnd(query.length + 1 + lvl) + "[term:" + range + "]"
+              }
               Object.entries(obj).filter(x => x[0].endsWith("@range") && x[0].length > 6).map(([_, range]) => {
-                s += '\n' + "".padStart(range[0] - 1) + "m".padEnd(range[1] - range[0] + 1, "-")
+                s += '\n' + ("".padStart(range[0] - 1) + "m".padEnd(range[1] - range[0] + 1, "-")).padEnd(query.length + 1 + lvl + 1) + "[term:mod:" + range + "]"
               })
-              if ("@range" in obj)
-                s += '\n' + "".padStart(obj["@range"][0] - 1) + "t".padEnd(obj["@range"][1] - obj["@range"][0] + 1, "-")
             } else if ("op" in obj) {
-              if ("@pos" in obj)
-                s += '\n' + "r".padEnd(obj.op.length, "-").padStart(obj["@pos"] + obj.op.length - 1)
-              
-              Object.entries(obj).filter(x => x[0].endsWith("@range")).map(([_, range]) => {
-                s += '\n' + "".padStart(range[0] - 1) + "m".padEnd(range[1] - range[0] + 1, "-")
+              if ("@range" in obj) {
+                let range = obj["@range"];
+                s += '\n' + ("".padStart(range[0] - 1) + "o".padEnd(range[1] - range[0] + 1, "-")).padEnd(query.length + 1 + lvl) + "[op:" + range + "]"
+              } else if ("@pos" in obj) {
+                let range = [obj["@pos"], obj["@pos"] + obj.op.length - 1]
+                s += '\n' + ("o".padEnd(obj.op.length, "-").padStart(obj["@pos"] + obj.op.length - 1)).padEnd(query.length + 1 + lvl) + "[op:" + range + "]"
+              }
+              Object.entries(obj).filter(x => x[0].endsWith("@range")  && x[0].length > 6).map(([_, range]) => {
+                s += '\n' + ("".padStart(range[0] - 1) + "m".padEnd(range[1] - range[0] + 1, "-")).padEnd(query.length + 1 + lvl + 1) + "[op:mod:" + range + "]"
               })
-              
-              s = recMods(obj.s1, s);
-              s = recMods(obj.s2, s);
+              s = recMods(obj.s1, s, lvl+1);
+              s = recMods(obj.s2, s, lvl+1);
             }
             return s;
           }

--- a/index.html
+++ b/index.html
@@ -15,8 +15,13 @@
                 cp.parseFromFQ(fq);
                 document.getElementById("output4").value = cp.toString();
             } catch (e) {
-                document.getElementById("output").value = e.message;
-                document.getElementById("output2").value = e.message;
+                var msg = e.toString();
+                msg += "\n\n\tquery: " + e.query + "\n\t       " + "^".padStart(e.pos) + " (pos: " + e.pos + ")";
+                msg += "\n\n\tcontext: " + JSON.stringify({"look": e.look, "val": e.val, "lval": e.lval});
+                document.getElementById("output").value = msg;
+                document.getElementById("output2").value = "";
+                document.getElementById("output3").value = "";
+                document.getElementById("output4").value = "";
                 throw e;
             }
         }

--- a/index.html
+++ b/index.html
@@ -16,8 +16,13 @@
                 let range = obj["@range"];
                 s += '\n' + ("".padStart(range[0] - 1) + "t".padEnd(range[1] - range[0] + 1, "-")).padEnd(query.length + 1 + lvl) + "[term:" + range + "]"
               }
+              if ("relation@pos" in obj) {
+                let relpos = obj["relation@pos"];
+                let relmodend = Math.max(...Object.entries(obj).filter(x => x[0].endsWith("@range") && x[0].length > 6).map(([_, range]) => range[1]));
+                s += '\n' + ("".padStart(relpos - 1) + "r".padEnd(relmodend - relpos + 1, "-")).padEnd(query.length + 1 + lvl + 1) + "[term:rel:" + obj["relation"] + ":" + relpos + "]"
+              }
               Object.entries(obj).filter(x => x[0].endsWith("@range") && x[0].length > 6).map(([_, range]) => {
-                s += '\n' + ("".padStart(range[0] - 1) + "m".padEnd(range[1] - range[0] + 1, "-")).padEnd(query.length + 1 + lvl + 1) + "[term:mod:" + range + "]"
+                s += '\n' + ("".padStart(range[0] - 1) + "m".padEnd(range[1] - range[0] + 1, "-")).padEnd(query.length + 1 + lvl + 2) + "[term:mod:" + range + "]"
               })
             } else if ("op" in obj) {
               if ("@range" in obj) {

--- a/index.html
+++ b/index.html
@@ -66,6 +66,28 @@
             }
         }
     </script>
+    <style type="text/css">
+      .output {
+        position: relative;
+        width: 49%;
+        display: inline-block;
+      }
+      .output > textarea {
+        width: 100%;
+
+      }
+      .output > .label {
+        position: absolute;
+        top: 1ex;
+        right: 1ex;
+        padding: 3px;
+        margin: 0px;
+        color: #0000005e;
+        border: 1px solid #0000005e;
+        border-radius: 3px;
+        pointer-events: none;
+      }
+    </style>
     <title>CQL parser</title>
   </head>
   <body>
@@ -73,16 +95,27 @@
       <form name="test" onsubmit="parseInput(this.q.value); return false;">
         Query: 
         <input type="text" name="q" size="160" onkeyup="parseInput(this.value); return false;"></input>
-        <br>
-        <br>
-        XCQL:
-        <br>
       </form>
-      <textarea id="output" rows="80" cols="80"></textarea>
-      <textarea id="output2" rows="80" cols="80"></textarea>
-      <textarea id="output3" rows="80" cols="80"></textarea>
-      <textarea id="output4" rows="80" cols="80"></textarea>
-      <textarea id="output5" rows="80" cols="80"></textarea>
+      <div class="output">
+        <div class="label">XCQL</div>
+        <textarea id="output" rows="10" cols="80" readonly></textarea>
+      </div>
+      <div class="output">
+        <div class="label">String</div>
+        <textarea id="output2" rows="10" cols="80" readonly></textarea>
+      </div>
+      <div class="output">
+        <div class="label">FQ</div>
+        <textarea id="output3" rows="10" cols="80" readonly></textarea>
+      </div>
+      <div class="output">
+        <div class="label">String (FQ-parsed)</div>
+        <textarea id="output4" rows="10" cols="80" readonly></textarea>
+      </div>
+      <div class="output">
+        <div class="label">Annotated<br/>(original input)</div>
+        <textarea id="output5" rows="8" cols="80" readonly></textarea>
+      </div>
     </div>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,37 @@
     <script type="text/javascript">
         var cp = new CQLParser();
         
+        function buildVis(query) {
+          var cp = new CQLParser();
+          cp.parse(query);
+          var fq = JSON.parse(cp.toFQ());
+
+          function recMods (obj, s) {
+            if ("term" in obj) {
+              Object.entries(obj).filter(x => x[0].endsWith("@range") && x[0].length > 6).map(([_, range]) => {
+                s += '\n' + "".padStart(range[0] - 1) + "m".padEnd(range[1] - range[0] + 1, "-")
+              })
+              if ("@range" in obj)
+                s += '\n' + "".padStart(obj["@range"][0] - 1) + "t".padEnd(obj["@range"][1] - obj["@range"][0] + 1, "-")
+            } else if ("op" in obj) {
+              if ("@pos" in obj)
+                s += '\n' + "r".padEnd(obj.op.length, "-").padStart(obj["@pos"] + obj.op.length - 1)
+              
+              Object.entries(obj).filter(x => x[0].endsWith("@range")).map(([_, range]) => {
+                s += '\n' + "".padStart(range[0] - 1) + "m".padEnd(range[1] - range[0] + 1, "-")
+              })
+              
+              s = recMods(obj.s1, s);
+              s = recMods(obj.s2, s);
+            }
+            return s;
+          }
+
+          var vis = query;
+          vis = recMods(fq, vis);
+          return vis;
+        }
+
         function parseInput(query) {
             try {
                 cp.parse(query);
@@ -14,6 +45,8 @@
                 document.getElementById("output3").value = fq;
                 cp.parseFromFQ(fq);
                 document.getElementById("output4").value = cp.toString();
+                // visualize positions/ranges in original query
+                document.getElementById("output5").value = buildVis(query);
             } catch (e) {
                 var msg = e.toString();
                 msg += "\n\n\tquery: " + e.query + "\n\t       " + "^".padStart(e.pos) + " (pos: " + e.pos + ")";
@@ -22,6 +55,7 @@
                 document.getElementById("output2").value = "";
                 document.getElementById("output3").value = "";
                 document.getElementById("output4").value = "";
+                document.getElementById("output5").value = "";
                 throw e;
             }
         }
@@ -42,6 +76,7 @@
       <textarea id="output2" rows="80" cols="80"></textarea>
       <textarea id="output3" rows="80" cols="80"></textarea>
       <textarea id="output4" rows="80" cols="80"></textarea>
+      <textarea id="output5" rows="80" cols="80"></textarea>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Only cosmetic changes:
* (a516856c2a214a6c7b5e4a45975fd53317e785e3) Reformatted `cql.js` code (Visual Studio Code default Javascript settings)
* (b22a83f18490e88155dbc67d58258b3f675d03cb) added a comment for how to use `cql.js` in a module manner, e.g. react etc.
* (9b8ab81e6c64580eefd65681bc2a0bd2884ffb19) Formatted some spaces
* (c2037d81123f2b6a2c3d37665d4ae4a45aaa21e8) Added comments to explain object fields/properties
* (95764ea56723488f224c7a744a4997c841709a15) Update demo page (add labels for output fields)

Adding position/range computation:
* f121b10222a52417810b32608146585c25e7ad43 Added custom error class `CQLError` to track more state (currently only actual input `query`, `pos`ition in string and some parsing context) to help with interpreting queries. Still needs some more manual work e.g. providing hints for fixing the query or some positioning in the query string.
_Note: forgot `let _qi = this.qi;` which was added in 5d05ecfc17dea37548b0c7d0cf425f27977c681d around line 360_
* 5d05ecfc17dea37548b0c7d0cf425f27977c681d ... 121948257a41872e3b17634b8006ce0e6997bedc Added more context to parsed query classes, e.g. position (`@pos`) / range (`@range`) of terms and operators in original query. May be used for highlighting etc. Added fifth output box in demo HTML page to demonstrate the extra range properties.
* 908005a219f6142157e946ca916069d6608cdfaf + eb057498605b0bcbfa467febd8695cf376bd019a + ea00edd5f6851eb13837174c060e80ffba21bffb Add relation start position (for annotating, see demo)
_Note: only serialized in the `FQ` methods (ignored when loading with `cql.js` but might introduce incompatibilities with other tools or libraries that just take any JSON key as some modifier.)_

NOTE: Indizes in `@pos` or `@range` are inclusive and start with **`1`**.

I tried to test as many possible variants I could think of. There might be some issues but I hope I found and fixed most.
The original parsing code was left untouched, so nothing should be broken there.